### PR TITLE
Add: 質問投稿機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@
 /public/packs
 /public/packs-test
 /node_modules
+/public/uploads
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'carrierwave'
 gem 'sorcery'
+gem 'dotenv-rails'
 gem 'fog-aws'
 gem 'carrierwave-audio'
 gem 'high_voltage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,10 @@ GEM
     crass (1.0.6)
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     enum_help (0.0.18)
       activesupport (>= 3.0.0)
     erubi (1.10.0)
@@ -349,6 +353,7 @@ DEPENDENCIES
   capybara
   carrierwave
   carrierwave-audio
+  dotenv-rails
   enum_help
   factory_bot_rails
   faker

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,48 @@
+class QuestionsController < ApplicationController
+  before_action :set_question, only: %i[show edit update destroy]
+
+  def index
+    @question = Question.all
+  end
+
+  def new
+    @question = Question.new
+  end
+
+  def create
+    @question = Question.new(question_params)
+    if @question.save
+      redirect_to questions_path
+    else
+      set_question
+      render :index
+    end
+  end
+
+  def show; end
+
+  def edit;end
+
+  def update
+    if @question.update(question_params)
+      redirect_to questions_path
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @question.destroy
+    redirect_to questions_path
+  end
+
+  private
+
+  def question_params
+    params.require(:question).permit(:category_id, :title, :question_voice_data)
+  end
+
+  def set_question
+    @question = Question.find(params[:id])
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
   validates :name, presence: true
+  has_many :questions
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,6 @@
+class Question < ApplicationRecord
+  mount_uploader :question_voice_data, QuestionVoiceDataUploader
+  validates :category_id, presence: true
+  validates :title, presence: true
+  belongs_to :category
+end

--- a/app/uploaders/question_voice_data_uploader.rb
+++ b/app/uploaders/question_voice_data_uploader.rb
@@ -1,0 +1,50 @@
+class QuestionVoiceDataUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog # 本番環境のみ
+  else
+    storage :file # 本番環境以外
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,0 +1,26 @@
+<div class="container">
+  <div class="row">
+    <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
+      <h1>質問登録</h1>
+      <%= form_with model: @question, local: true do |f| %>
+      <%= render 'shared/error_messages', model: f.object %>
+        <div class="form-group">
+          <%= f.label :category_id %>
+          <%= f.number_field :category_id, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :title %>
+          <%= f.text_field :title, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :question_voice_data %>
+          <%= f.file_field :question_voice_data, class: 'form-control' %>
+        </div>
+        <%= f.submit '登録', class: 'btn btn-primary' %>
+      <% end %>
+      <div class='text-center'>
+        <%= link_to 'ログインページへ', login_path %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %> 

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,0 +1,12 @@
+<% @question.each do |question| %>
+<p><%= question.category_id %></p>
+<p><%= question.title %></p>
+<p><%= question.question_voice_data %></p>
+
+<% if question.question_voice_data.present? %>
+  <%=audio_tag("#{question.question_voice_data.url}", controls: true) %>
+<% end %>
+  <%= link_to "編集", edit_question_path(question) %>
+<% end %>
+
+<%= link_to "新規登録", new_question_path, class: "btn btn-primary" %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %> 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,1 +1,2 @@
 <%= link_to "今すぐはじめる", "#", class: "btn btn-primary" %>
+<%= link_to "質問", questions_path, class: "btn btn-primary" %>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,16 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory  = 'prepvoice1' # 作成したバケット名を記述
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'], # 環境変数
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'], # 環境変数
+      region: 'ap-northeast-1',   # アジアパシフィック(東京)を選択した場合
+      path_style: true
+    }
+end 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   delete 'logout', to: 'user_sessions#destroy'
   resources :users, only: %i[new create]
   resources :categories, except: %i[show]
+  resources :questions
 end

--- a/db/migrate/20220302050651_create_questions.rb
+++ b/db/migrate/20220302050651_create_questions.rb
@@ -1,0 +1,11 @@
+class CreateQuestions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :questions do |t|
+      t.references :category, null: false
+      t.string :title, null: false
+      t.string :question_voice_data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_01_130829) do
+ActiveRecord::Schema.define(version: 2022_03_02_050651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,15 @@ ActiveRecord::Schema.define(version: 2022_03_01_130829) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.string "title", null: false
+    t.string "question_voice_data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["category_id"], name: "index_questions_on_category_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
### 概要

- questionsテーブル、モデル、コントローラを追加
- question_voice_data(音声ファイル)をアップロードするために、Carrierwaveを使用
- 本番環境の音声ファイル保存先として、AWSのS3を指定
- カテゴリーと質問の関係を1対多に設定
