### PR TITLE
Fix: training作成フォームから想定していない値が送信されるバグを修正 #30

### DIFF
--- a/app/controllers/trainings_controller.rb
+++ b/app/controllers/trainings_controller.rb
@@ -26,7 +26,7 @@ class TrainingsController < ApplicationController
   end
 
   def show
-    @training = Training.find(params[:id])
+    @training = current_user.trainings.find(params[:id])
     @question = @training.question
     @question_title = @training.question.title
     @question_voice_data = @training.question.question_voice_data

--- a/app/javascript/packs/training.js
+++ b/app/javascript/packs/training.js
@@ -1,0 +1,9 @@
+let opts = document.querySelectorAll('.radio');
+for (let i = 0; i < opts.length; i++) {
+  let opt = opts[i];
+  opt.addEventListener('click', function(){
+  console.log(this.id + '-title');
+  hiddenRadio = document.getElementById(this.id + '-title');
+  hiddenRadio.click();
+});
+}

--- a/app/views/trainings/_table.html.erb
+++ b/app/views/trainings/_table.html.erb
@@ -6,9 +6,9 @@
         <li class = "list-header font">質問リスト</li>
         <% @questions.each do |question| %>
           <li class="list-group-item font">
-            <%= f.radio_button :question_id, question.id %>
+            <%= f.radio_button :question_id, question.id, id: "question-#{question.id}", class: "radio" %>
             <%= f.label :queston_id, question.title, value: question.id %>
-            <%= f.hidden_field :title, value: question.title %>
+            <%= f.radio_button :title, question.title, class: "d-none", id: "question-#{question.id}-title"%>
           </li>
         <% end %>
       </ul>
@@ -18,3 +18,5 @@
     </div>
   <% end %>
 </div>
+
+<%= javascript_pack_tag 'training' %>


### PR DESCRIPTION
### バグの内容
training作成フォームから想定していない値が送信される。
選択した質問のidは正しいが、別の質問のtitleが保存される。

### 原因
question_id は radio button になっているので、選択した id が training[question_id] に設定され、
```
def training_params
  params.require(:training).permit(:user_id, :question_id, :title)
end
```
で取得できる、title は単に hidden_field で設定されているだけなので、training[title]の値が、上から順番に上書きされていき、一番最後の質問の値が設定される。

### 対処

1. question_idのradioボタンにradioクラスと、question_idによって変化する動的なidを付与 （question-#{question.id}）
2. hidden_fieldだったtitleをradioボタンにする
3. 非表示にして、question_idによって変化する動的なidを付与（question-#{question.id}-title）
4. querySelecterAllでradioクラスを持つ要素を取得
5. for文で展開
6. 展開した要素1つ1つにクリックイベントを追加
7. クリックした要素のid-titleのidを持つ要素（titleのradioボタン）を取得
8. クリックする

```
<% @questions.each do |question| %>
  <li class="list-group-item font">
    <%= f.radio_button :question_id, question.id, id: "question-#{question.id}", class: "radio" %>
    <%= f.label :queston_id, question.title, value: question.id %>
    <%= f.radio_button :title, question.title, class: "d-none", id: "question-#{question.id}-title"%>
  </li>
<% end %>
```

```
let opts = document.querySelectorAll('.radio');
for (let i = 0; i < opts.length; i++) {
  let opt = opts[i];
  opt.addEventListener('click', function(){
  hiddenRadio = document.getElementById(this.id + '-title');
  hiddenRadio.click();
});
}
```