### PR TITLE
Fix: 最後の音声を保存するよりも前に画面遷移する

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -136,3 +136,71 @@ header {
   color: #fff;
   text-align: center;
 }
+/* アコーディオン
+   ========================================================================== */
+
+.accordion-container{
+  .accordion-title{
+    position: relative;
+    margin: 0;
+    font-size: 1.25em;
+    font-weight: normal;
+    cursor: pointer;
+    border-bottom: solid 1px #E9E9E7;
+
+    &:hover,
+    &:active,
+    &.open{
+      background-color: #EEF8FC;
+    }
+
+    &::before{
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: 25px;
+      width: 15px;
+      height: 2px;
+      /*縦線に*/
+      transform: rotate(90deg);
+      background: #000;
+      transition: all .3s ease-in-out;
+    }
+
+    &::after{
+      content: "";
+      position: absolute;
+      top: 50%;
+      right: 25px;
+      /*横線*/
+      width: 15px;
+      height: 2px;
+      background: #000;
+      transition: all .2s ease-in-out;
+    }
+
+    &.open::before {
+      transform: rotate(180deg);
+    }
+
+    &.open::after {
+      opacity: 0;
+    }
+
+    .date{
+      padding: 0.625em 0.625em 0.625em 2em;
+      width: 20%;
+    }
+    
+    .list-line{
+      position: relative;
+      padding: 12.5px 20px;
+    }
+  }
+  .accordion-content {
+    display: none;
+    padding-left: 2.3125em;
+    border: 1px solid #EEF8FC;
+  }
+}
+

--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -91,7 +91,7 @@ if (navigator.mediaDevices.getUserMedia) {
       } else {
         formData.append('phase', 'second_point');
       }
-      axios.post(document.querySelector('#voiceform').action, formData, {
+      axios.post(document.getElementById('voiceform').action, formData, {
         headers: {
         'content-type': 'multipart/form-data',
         }

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,37 +1,33 @@
 <div class="container">
-<h2 class = "text-center mt-5 mb-4"><%= @question.title %></h2>
-<table class = "table w-75 mx-auto">
-  <thead class = "thead-dark">
-    <tr>
-      <th class = "text-center">日付</th>
-      <th class = "text-center">タイトル</th>
-      <th></th>
-    </tr>
-  </thead>
-<% @trainings.each_with_index do |training, i| %>
-    <tr data-toggle="collapse" data-target="#trainingList<%= i + 1%>">
-      <td class="align-middle font text-center"><%= training.created_at.strftime('%Y/%m/%d') %></td>
-      <td class="align-middle font text-center"><%= "#{training.title}##{i+1}" %></td>
-      <td class="align-middle font text-center"><%= link_to "削除", training, method: :delete %></td>
-    </tr>
-    <tr>
-      <td colspan="2" class="p-0">
-        <div id="trainingList<%= i + 1%>" class="collapse">
-          <div class="px-4 py-2">
-            <% if training.voices.present? %>
-              <% training.voices.each do |voice| %>
-              <div class = "align-items-center row">
-                <div class = "text-center col-4"><%= voice.phase_i18n %></div>
-                <div class = "text-center col-8"><%= audio_tag(voice.voice_data, controls: true) %></div>
-              </div>
-              <% end %>
-            <% else %>
-              <p>まだ練習していません</p>
-            <% end %>
-          </div>
+<h2 class = "text-center mt-5 mb-4">行をクリックして、練習内容を振り返りましょう</h2>
+  <div id="accordion" class="accordion-container w-75 mx-auto">
+    <div class = "list-header font">質問タイトル：<%= @question.title %></div>
+  <% @trainings.each_with_index do |training, i| %>
+    <li class="accordion-title js-accordion-title d-flex font">
+      <span class = "date"><%= training.created_at.strftime('%Y/%m/%d') %></span>
+      <span class = "list-line"><%= i+1 %>回目の練習</span>
+    </li>
+    <div class="accordion-content">
+      <% if training.voices.present? %>
+        <% training.voices.each do |voice| %>
+        <div class = "align-items-center row">
+          <div class = "text-center col-4"><%= voice.phase_i18n %></div>
+          <div class = "text-center col-8"><%= audio_tag(voice.voice_data, controls: true) %></div>
         </div>
-      </td>
-    </tr>
-<% end %>
-</table>
+        <% end %>
+      <% else %>
+        <p>まだ練習していません</p>
+      <% end %>
+    </div>
+  <% end %>
+  </div>
 </div>
+<script>
+$(function () {
+  // タイトルをクリックすると
+  $(".js-accordion-title").on("click", function () {
+    $(this).next().slideToggle(300);
+    $(this).toggleClass("open", 300);
+  });
+});
+</script>

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -29,7 +29,7 @@
     <div id = "buttons", class = 'text-center'>
       <button class = "record btn btn-lg bg text-white"><i class="fas fa-microphone fa-lg pr-3"></i>録音スタート</button>
       <button class = "stop d-none btn btn-lg bg text-white">次のフェーズへ</button>
-      <%= link_to "完了",question_path(@question), id: 'finish', class: "btn btn-warning d-none" %>
+      <%= link_to "完了",question_path(@question), id: 'finish', class: "d-none" %>
     </div>
     <%= audio_tag(@question_voice_data, id: "question-voice") %>
     <p id = "seconds" class = "d-none"><%= @question_voice_data_seconds %></p>


### PR DESCRIPTION
### 概要
処理速度の問題から、最後の録音音声を保存するよりも前に画面遷移すると仮定
querySelectorからgetElementByIdに変更して、処理速度を上げる