### PR TITLE
Fix: 最後の音声を保存するよりも前に画面遷移する[2]

### DIFF
--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -95,14 +95,17 @@ if (navigator.mediaDevices.getUserMedia) {
         headers: {
         'content-type': 'multipart/form-data',
         }
-        }).catch(error => {
-        console.log(error.response)
-       })
-
-      if (count == 4) {
-        count = 0;
-        finish.click();
-      }
+      })
+      .then(function (response) {
+        // handle success
+        if (count == 4) {
+          count = 0;
+          finish.click();
+        }
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
     }
   }
 

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -33,7 +33,7 @@
     </div>
     <%= audio_tag(@question_voice_data, id: "question-voice") %>
     <p id = "seconds" class = "d-none"><%= @question_voice_data_seconds %></p>
-    <%= form_with model: @voice, url: training_voices_path(@training), id: "voiceform", local: true do |f| %>
+    <%= form_with model: @voice, url: training_voices_path(@training), id: "voiceform" do |f| %>
       <%= f.hidden_field :training_id,value: @training.id %>
       <%= f.hidden_field :phase %>
       <%= f.hidden_field :voice_data  %>


### PR DESCRIPTION
### 概要
最後の音声を保存するよりも前に画面遷移するバグが発生中
最後の録音音声のPOST通信に成功したら、画面遷移を行う仕様に修正