### PR TITLE
Fix: 最後の音声を保存するよりも前に画面遷移する[3] 

### DIFF
--- a/app/javascript/packs/app.js
+++ b/app/javascript/packs/app.js
@@ -96,15 +96,14 @@ if (navigator.mediaDevices.getUserMedia) {
         'content-type': 'multipart/form-data',
         }
       })
-      .then(function (response) {
-        // handle success
+      .catch(function (error) {
+        console.log(error);
+      })
+      .finally(function () {
         if (count == 4) {
           count = 0;
           finish.click();
         }
-      })
-      .catch(function (error) {
-        console.log(error);
       });
     }
   }


### PR DESCRIPTION
### 前回の修正
録音後の画面遷移を、then()メソッドで実行する仕様に変更した。
その結果、4つ目の録音が開始した直後に画面遷移するようになった。
then()メソッドは、「通信を完了したら実行する」という意味ではなく、「通信に成功したら実行」のような意味みたい。

### 今回の修正
録音後の画面遷移を、finally()メソッドで実行する仕様に変更した。
[MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally)では、「Promise が処理された後に実行されなければならないコードを提供できます」と書いてあるため、POST通信終了後に画面遷移が実行されることを期待。