### PR TITLE
Fix: 最後の音声を保存するよりも前に画面遷移する[9]

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -22,7 +22,7 @@ class QuestionsController < ApplicationController
   def show
     @question = Question.find(params[:id])
     @trainings = @question.trainings.order("id")
-    @voices = Question.includes(trainings: :voices)
+    @voices = Question.includes(trainings: :voices).order("id")
   end
 
   def edit;end

--- a/app/views/trainings/show.html.erb
+++ b/app/views/trainings/show.html.erb
@@ -29,7 +29,7 @@
     <div id = "buttons", class = 'text-center'>
       <button class = "record btn btn-lg bg text-white"><i class="fas fa-microphone fa-lg pr-3"></i>録音スタート</button>
       <button class = "stop d-none btn btn-lg bg text-white">次のフェーズへ</button>
-      <%= link_to "完了",question_path(@question), id: 'finish', class: "d-none" %>
+      <%= link_to "完了",question_path(@question), id: 'finish', class: "d-none", data: { 'turbolinks': false } %>
     </div>
     <%= audio_tag(@question_voice_data, id: "question-voice") %>
     <p id = "seconds" class = "d-none"><%= @question_voice_data_seconds %></p>


### PR DESCRIPTION
### 概要

- jsではなくTurbolinksが原因の可能性があるため、画面遷移するリンクのTurbolinksを無効化
- 稀に音声の順序がおかしくなるため、idで昇順に

### Turbolinksが原因でリロードしないと動作しない事例
https://mebee.info/2021/07/29/post-28286/
https://qiita.com/shibata0406/items/861df68467f3bee22a94