### PR TITLE
Fix: ユーザー新規登録失敗時のエラーを解消

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -240,6 +240,7 @@ header {
     .text-left{
       display: inline-block;
       margin-top: 22px;
+      line-height: 1.8;
     }
     .prep-flow{
       text-align: left;
@@ -387,6 +388,7 @@ header {
         font-size: 24px;
         font-weight: 600;
         color: #0D6CBE;
+        margin-bottom: 1rem;
       }
       .list-number{
         display: inline-block;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ class UsersController < ApplicationController
     # ログイン済みユーザーの場合は新規登録画面を表示しない
     logged_in
     @user = User.new
+    @category = Category.all
   end
 
   def create

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   end
 
   def create
+    @category = Category.all
     @user = User.new(user_params)
     if @user.save
       redirect_to login_path, success: t('.success')

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -8,7 +8,7 @@
           <td><%= current_user.email %></td>
         </tr>
         <tr>
-          <th scope="row">使用シーン</th>
+          <th scope="row">面接シーン</th>
           <td><%= @category %></td>
         </tr>
       </table>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,18 +10,12 @@
         </div>
         <div class="form-group">
         <%= f.label '面接シーンを選択してください', class: 'font-weight-bold' %>
-          <div class="custom-radio">
-            <%= f.radio_button  :category_id, 1 %>
-            <%= f.label :category_id, '新卒',value: 1 %>
-          </div>
-          <div class="custom-radio">
-            <%= f.radio_button  :category_id, 2 %>
-            <%= f.label :category_id, '転職',value: 2 %>
-          </div>
-          <div class="custom-radio">
-            <%= f.radio_button  :category_id, 3 %>
-            <%= f.label :category_id, 'エンジニア',value: 3 %>
-          </div>
+          <% @category.each do |category| %>
+            <div class="custom-radio">
+              <%= f.radio_button  :category_id, category.id %>
+              <%= f.label :category_id, category.name, value: category.id %>
+            </div>
+          <% end %>
         </div>
         <div class="form-group">
           <%= f.label :password, class: 'font-weight-bold' %>

--- a/spec/system/users/users_spec.rb
+++ b/spec/system/users/users_spec.rb
@@ -1,18 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
-  let(:category) { create(:category) }
+  fdescribe 'ユーザー新規登録' do
+    let!(:category) { create(:category, :category2) }
 
-  xdescribe 'ユーザー新規登録' do
     context 'フォームの入力値が正常' do
       it 'ユーザーの新規作成が成功する' do
         visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
-        choose '新卒' # category_id: 1はすでにロールバックで削除されているため、選択できない。手動でテストを行う
+        choose '転職' # category_id: 1はすでにロールバックで削除されているため、選択できない。手動でテストを行う
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
-        expect(page).to have_checked_field('新卒')
         expect(page).to have_content 'ユーザー登録しました'
         expect(page).to have_current_path login_path, ignore_query: true
       end
@@ -21,8 +20,7 @@ RSpec.describe 'Users', type: :system do
     context 'メールアドレスが未入力' do
       it 'ユーザーの新規作成が失敗する' do
         visit new_user_path
-        fill_in 'メールアドレス', with: ''
-        choose '新卒'
+        choose '転職'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
@@ -36,7 +34,7 @@ RSpec.describe 'Users', type: :system do
         existed_user = create(:user)
         visit new_user_path
         fill_in 'メールアドレス', with: existed_user.email
-        choose '新卒'
+        choose '転職'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
@@ -50,7 +48,6 @@ RSpec.describe 'Users', type: :system do
       it 'ユーザーの新規作成が失敗する' do
         visit new_user_path
         fill_in 'メールアドレス', with: 'exam2@example.com'
-        choose '新卒'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
@@ -64,7 +61,7 @@ RSpec.describe 'Users', type: :system do
       it 'ユーザーの新規作成が失敗する' do
         visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
-        choose '新卒'
+        choose '転職'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
         expect(page).to have_content 'パスワードを入力してください'
@@ -77,7 +74,7 @@ RSpec.describe 'Users', type: :system do
       it 'ユーザーの新規作成が失敗する' do
         visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
-        choose '新卒'
+        choose '転職'
         fill_in 'パスワード', with: 'password'
         click_button '登録する'
         expect(page).to have_content 'パスワード確認を入力してください'

--- a/spec/system/users/users_spec.rb
+++ b/spec/system/users/users_spec.rb
@@ -2,13 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
   fdescribe 'ユーザー新規登録' do
+    let!(:existed_user) { create(:user) }
     let!(:category) { create(:category, :category2) }
+
+    before do
+      visit new_user_path
+    end
 
     context 'フォームの入力値が正常' do
       it 'ユーザーの新規作成が成功する' do
-        visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
-        choose '転職' # category_id: 1はすでにロールバックで削除されているため、選択できない。手動でテストを行う
+        choose '転職'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
@@ -19,34 +23,30 @@ RSpec.describe 'Users', type: :system do
 
     context 'メールアドレスが未入力' do
       it 'ユーザーの新規作成が失敗する' do
-        visit new_user_path
         choose '転職'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
         expect(page).to have_content 'メールアドレスを入力してください'
-        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_current_path users_path
       end
     end
 
     context '登録済のメールアドレスを使用' do
       it 'ユーザーの新規作成が失敗する' do
-        existed_user = create(:user)
-        visit new_user_path
         fill_in 'メールアドレス', with: existed_user.email
         choose '転職'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
         click_button '登録する'
         expect(page).to have_content 'メールアドレスはすでに存在します'
-        expect(page).to have_current_path users_path, ignore_query: true
+        expect(page).to have_current_path users_path
         expect(page).to have_field 'メールアドレス', with: existed_user.email
       end
     end
 
     context 'category_idが未入力' do
       it 'ユーザーの新規作成が失敗する' do
-        visit new_user_path
         fill_in 'メールアドレス', with: 'exam2@example.com'
         fill_in 'パスワード', with: 'password'
         fill_in 'パスワード確認', with: 'password'
@@ -59,7 +59,6 @@ RSpec.describe 'Users', type: :system do
 
     context 'パスワードが未入力' do
       it 'ユーザーの新規作成が失敗する' do
-        visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
         choose '転職'
         fill_in 'パスワード確認', with: 'password'
@@ -72,7 +71,6 @@ RSpec.describe 'Users', type: :system do
 
     context 'パスワード確認が未入力' do
       it 'ユーザーの新規作成が失敗する' do
-        visit new_user_path
         fill_in 'メールアドレス', with: 'exam@example.com'
         choose '転職'
         fill_in 'パスワード', with: 'password'


### PR DESCRIPTION
### 概要

- ユーザー新規登録ページのcategory_idラジオボタンを動的に