### PR TITLE
Fix: ゲストログイン時に稀に発生するエラーを解消

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -22,7 +22,7 @@ class UserSessionsController < ApplicationController
   end
 
   def guest_login
-    redirect_to root_path, alert: t('defaults.message.logged_in') if current_user # ログインしてる場合はユーザーを作成しない
+    logged_in and return
 
     random_value = SecureRandom.hex
     user = User.create!(email: "guest_#{random_value}@example.com", role: :guest, category_id: 1, password: random_value, password_confirmation: random_value)


### PR DESCRIPTION
ゲストログイン時に、以下のようなエラーが稀に発生する
```
AbstractController::DoubleRenderError (Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return".):
```

### 考えられる原因
おそらく、redirect_to()が複数あったから
[Railsガイド](https://railsguides.jp/layouts_and_rendering.html#%E4%BA%8C%E9%87%8D%E3%83%AC%E3%83%B3%E3%83%80%E3%83%AA%E3%83%B3%E3%82%B0%E3%82%A8%E3%83%A9%E3%83%BC%E3%82%92%E9%81%BF%E3%81%91%E3%82%8B)を参考に、`and return`を付加してみる

```
# and returnを付加
logged_in and return 

random_value = SecureRandom.hex
user = User.create!(email: "guest_#{random_value}@example.com", role: :guest, category_id: 1, password: random_value, password_confirmation: random_value)
auto_login(user)
redirect_to new_training_path
```

